### PR TITLE
Update squid.conf

### DIFF
--- a/squid-test/files/squid.conf
+++ b/squid-test/files/squid.conf
@@ -1,9 +1,11 @@
 #
 # Recommended minimum configuration:
 #
-acl manager proto cache_object
-acl localhost src 127.0.0.1/32 ::1
-acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+# following three acl removed due to upgrade of squid to 3.3.x
+#
+#acl manager proto cache_object
+#acl localhost src 127.0.0.1/32 ::1
+#acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
 
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing


### PR DESCRIPTION
remove three acl from config due to squid upgrade to 3.3.x
squid would not start
